### PR TITLE
Origin blacklist and Airing check delay

### DIFF
--- a/anilist-downloader-module.js
+++ b/anilist-downloader-module.js
@@ -253,7 +253,7 @@ var trackers = {
             logi(`Parsing info from feed entry - ${entry}`)
 
             // Standard Match
-            const regexPattern = /\[(.+?)\]\s+(.+?)\s+-\s+S?(\d\d)\s+\[(.+?)\]/
+            const regexPattern = /\[(.+?)\]\s+(.+?)\s+-\s+(?:S\d\dE)?(\d\d)\s+\[(.+?)\]/i
             const match = entry.match(regexPattern)
             if (match) {
                 return new FeedEntry(link, match[1], match[2], match[3], this.parseQualityFromString(match[4]), false, seeders)
@@ -533,7 +533,7 @@ var qbt = {
 
         const downloadRule = {
             "enabled": true,
-            "mustContain": strictMatchRule ? strictMatchRule : "",
+            "mustContain": strictMatchRule ? strictMatchRule.replace(/\(/g, "\\(").replace(/\)/g, "\\)") : "", // escape brackets if detected
             "mustNotContain": strictMatchRule ? "batch" : "",
             "useRegex": strictMatchRule ? true : false,
             "episodeFilter": "",

--- a/anilist-downloader-module.js
+++ b/anilist-downloader-module.js
@@ -526,15 +526,31 @@ var qbt = {
             logi(`Failed to remove RSS feed title ${title} - this is normal for initial setup.`)
         }
     },
+    /**
+     * Adds an auto-download rule for an RSS feed. Without an auto-download rule nothing from a feed will be downloaded.
+     * 
+     * @param {*} feed The RSS feed URL.
+     * @param {*} title The title of the anime.
+     * @param {*} animeInfo The AnimeInfo object for tracking.
+     * @param {*} strictMatchRule A filter string that a feed entry title must have. If not defined everything in the feed will be downloaded.
+     */ 
     addRule: async function(feed, title, animeInfo, strictMatchRule) {
         logi(`[QBT] Adding rule ${title}`)
 
         const apiUri = '/api/v2/rss/setRule?'
 
+        const additionalIgnoreRules = []
+        if (strictMatchRule) {
+            // In general when a strictMatchRule is set we want to ignore any batch results (the batch flow handles that).
+            additionalIgnoreRules.push("batch")
+        }
+        // TODO: May want filter out blacklisted words if its contained in the strict match rule. (nothing will download)
+        const ignore = settings.ANI.BLACKLISTED_TITLE_WORDS.concat(additionalIgnoreRules).join("|")
+
         const downloadRule = {
             "enabled": true,
             "mustContain": strictMatchRule ? strictMatchRule.replace(/\(/g, "\\(").replace(/\)/g, "\\)") : "", // escape brackets if detected
-            "mustNotContain": strictMatchRule ? "batch" : "",
+            "mustNotContain": ignore,
             "useRegex": strictMatchRule ? true : false,
             "episodeFilter": "",
             "smartFilter": false,

--- a/anilist-downloader-settings.js
+++ b/anilist-downloader-settings.js
@@ -7,6 +7,9 @@ module.exports = {
         BLACKLISTED_ORIGINS: [ 
             "CN" // by default "CN" is backlisted as it'll generally have no results causing a lot of unnecessary overhead.
         ],
+        BLACKLISTED_TITLE_WORDS: [
+            "v0" // some groups use v0 to indicate a first pass in subbing, meaning a better version should be released shortly
+        ]
     },
     QBT: {
         PORT: 8080,

--- a/anilist-downloader-settings.js
+++ b/anilist-downloader-settings.js
@@ -1,6 +1,6 @@
 module.exports = {
     SHARED: {
-        DELAY: 10000, 
+        DELAY: 5 * 1000,
     },
     ANI: {
         LISTS: [ "Watching", "APS-Request" ],
@@ -9,7 +9,8 @@ module.exports = {
         ],
         BLACKLISTED_TITLE_WORDS: [
             "v0" // some groups use v0 to indicate a first pass in subbing, meaning a better version should be released shortly
-        ]
+        ],
+        REQUIRED_AIRING_DURATION: 7 * 24 * 60 * 60 * 1000 // must air for (7) days before attempting
     },
     QBT: {
         PORT: 8080,

--- a/anilist-downloader-settings.js
+++ b/anilist-downloader-settings.js
@@ -3,7 +3,10 @@ module.exports = {
         DELAY: 10000, 
     },
     ANI: {
-        LISTS: [ "Watching", "APS-Request" ]
+        LISTS: [ "Watching", "APS-Request" ],
+        BLACKLISTED_ORIGINS: [ 
+            "CN" // by default "CN" is backlisted as it'll generally have no results causing a lot of unnecessary overhead.
+        ],
     },
     QBT: {
         PORT: 8080,

--- a/app.js
+++ b/app.js
@@ -41,13 +41,12 @@ app.get('/users', function(request, resource) {
 })
 
 app.get('/animes', function(request, resource) {
-  var animes = aniDownloader.getData().animes
-  // slightly dangerous as we're reordering the source array
+  var animes = aniDownloader.getData().animes.filter((entry) => { return entry.title })
   animes.sort((lhs, rhs) => {
-    const LARGE = 10000
-    const l = (lhs.noResults || lhs.isBlacklisted) ? LARGE : 0
-    const r = (rhs.noResults || rhs.isBlacklisted) ? LARGE : 0
-    return lhs.title.localeCompare(rhs.title) + (l - r)
+    // const LARGE = 10000
+    // const l = (lhs.noResults || lhs.isBlacklisted) ? LARGE : 0
+    // const r = (rhs.noResults || rhs.isBlacklisted) ? LARGE : 0
+    return lhs.title.localeCompare(rhs.title) // + (l - r)
   })
 
   resource.render('animes', {

--- a/app.js
+++ b/app.js
@@ -45,8 +45,8 @@ app.get('/animes', function(request, resource) {
   // slightly dangerous as we're reordering the source array
   animes.sort((lhs, rhs) => {
     const LARGE = 10000
-    const l = lhs.noResults ? LARGE : 0
-    const r = rhs.noResults ? LARGE : 0
+    const l = (lhs.noResults || lhs.isBlacklisted) ? LARGE : 0
+    const r = (rhs.noResults || rhs.isBlacklisted) ? LARGE : 0
     return lhs.title.localeCompare(rhs.title) + (l - r)
   })
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -92,13 +92,22 @@ button {
 .primary-text {
   color: rgb(92, 114, 138)
 }
+.primary-text a {
+  color: rgb(92, 114, 138)
+}
 
 .warning-text {
   color: orange
 }
+.warning-text a {
+  color: orange
+}
 
 .error-text {
-  color: lightcoral;
+  color: lightcoral
+}
+.error-text a {
+  color: lightcoral
 }
 
 a {
@@ -217,3 +226,13 @@ a.logo * {
 /*
 color:rgb(237, 241, 245);
 */
+
+/* Page: Animes */
+#animes-table {
+  border-spacing: 10px;
+  text-align: left;
+}
+
+#animes-table .note-col {
+  vertical-align: top;
+}

--- a/views/animes.jade
+++ b/views/animes.jade
@@ -16,7 +16,10 @@ block content
     .body-container-contents
       div
         each item in animes
-          if (item.noResults)
+          if (item.isBlacklisted)
+            li
+              a(href="/anime/#{item.mediaId}" class="error-text") #{item.title} [BLACKLISTED]
+          else if (item.noResults)
             li
               a(href="/anime/#{item.mediaId}" class="error-text") #{item.title} [NO RESULTS]
           else if (item.manual)

--- a/views/animes.jade
+++ b/views/animes.jade
@@ -15,16 +15,38 @@ block content
     h3.primary-text Anime List
     .body-container-contents
       div
-        each item in animes
-          if (item.isBlacklisted)
-            li
-              a(href="/anime/#{item.mediaId}" class="error-text") #{item.title} [BLACKLISTED]
-          else if (item.noResults)
-            li
-              a(href="/anime/#{item.mediaId}" class="error-text") #{item.title} [NO RESULTS]
-          else if (item.manual)
-            li
-              a(href="/anime/#{item.mediaId}" class="primary-text") #{item.title} [MANUAL RULE]
-          else
-            li
-              a(href="/anime/#{item.mediaId}" class="primary-text") #{item.title}
+        table(id="animes-table")
+          tr(class="primary-text")
+            th Title
+            th Notes
+          each item in animes
+            if (item.manual)
+              tr(class="primary-text")
+                td 
+                  a(href="/anime/#{item.mediaId}") #{item.title}
+                td(class="note-col")
+                  span [MANURAL RULE]
+            else if (item.isBlacklisted)
+              tr(class="error-text")
+                td 
+                  a(href="/anime/#{item.mediaId}") #{item.title}
+                td(class="note-col")
+                  span [BLACKLISTED]
+            else if (item.noResults)
+              tr(class="error-text")
+                td 
+                  a(href="/anime/#{item.mediaId}") #{item.title}
+                td(class="note-col")
+                  span [NO RESULTS]
+            else if (item.downloadTime)
+              tr(class="warning-text")
+                td
+                  a(href="/anime/#{item.mediaId}") #{item.title}
+                td(class="note-col")
+                  span [Downloads on #{new Date(item.downloadTime).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}]
+            else
+              tr(class="primary-text")
+                td
+                  a(href="/anime/#{item.mediaId}" class="primary-text") #{item.title}
+                td(class="note-col")
+                  span


### PR DESCRIPTION
Adds
- **Country of origin blacklist** (by default Chinese animes are blacklisted as they'll generally have no results causing a lot of overhead)
- **Airing duration check**: Won't attempt to download an anime until it has aired for the specific duration (by default set to 7 days)
- **Torrent title blacklist** (by default all torrents with "v0" are now ignored. Some groups use this tag to indicate they will release a better version shortly)

Improvements
- Fix auto-download failure if a title had brackets. Eg. "jp title (romanji title)"
- Better torrent batch detection (now recognizes "S01E01" instead of just "01")
- The Animes page has been updated

Fixes
- console log colors

Tech
- Implemented a basic worker system to better coordinate jobs and throttle api requests.